### PR TITLE
vllm evaluation starter

### DIFF
--- a/lmdeploy_eval_config.json
+++ b/lmdeploy_eval_config.json
@@ -1,0 +1,17 @@
+{
+  "model": {
+    "vllm-Qwen2.5-VL-7B-Instruct": {
+      "class": "LMDeployAPI",
+      "api_base": "http://0.0.0.0:18902/v1/chat/completions",
+      "temperature": 0,
+      "retry": 10,
+      "system_prompt": "This is a [PLACEHOLDER] for SYSTEM_PROMPT"
+    }
+  },
+  "data": {
+    "VStarBench": {
+      "class": "ImageMCQDataset",
+      "dataset": "VStarBench"
+    }
+  }
+}

--- a/vlmeval/api/lmdeploy.py
+++ b/vlmeval/api/lmdeploy.py
@@ -256,13 +256,13 @@ class LMDeployWrapper(BaseAPI):
                 if msg['type'] == 'text':
                     content_list.append(dict(type='text', text=msg['value']))
                 elif msg['type'] == 'image':
-                    from PIL import Image
-                    img = Image.open(msg['value'])
-                    b64 = encode_image_to_base64(img)
+                    # Use Qwen's custom image preprocessing
+                    from ..vlm.qwen2_vl.model import encode_image
+                    b64, mime_type = encode_image(msg['value'])
                     extra_args = msg.copy()
                     extra_args.pop('type')
                     extra_args.pop('value')
-                    img_struct = dict(url=f'data:image/jpeg;base64,{b64}', **extra_args)
+                    img_struct = dict(url=f'data:{mime_type};base64,{b64}', **extra_args)
                     content_list.append(dict(type='image_url', image_url=img_struct))
         else:
             assert all([x['type'] == 'text' for x in inputs])

--- a/vlmeval/config.py
+++ b/vlmeval/config.py
@@ -439,7 +439,7 @@ api_models = {
     # lmdeploy api
     "lmdeploy": partial(
         LMDeployAPI,
-        api_base="http://0.0.0.0:23333/v1/chat/completions",
+        api_base="http://0.0.0.0:18902/v1/chat/completions",
         temperature=0,
         retry=10,
     ),


### PR DESCRIPTION
figure out how to use lmdeploy.py as entry point to do vllm model evaluation. Especially by using json to start:

```
vllm serve Qwen/Qwen2.5-VL-7B-instruct --port 18902 &
python run.py --config  lmdeploy_eval_config.json  --verbose
```

WIP: figure out how to inject system prompt into the template.
Currently i set custom_prompt in the json file only will not change system_prompt.

